### PR TITLE
Fix `library_private_types_in_public_api` lint

### DIFF
--- a/packages/flutter_background_service/example/lib/main.dart
+++ b/packages/flutter_background_service/example/lib/main.dart
@@ -116,7 +116,7 @@ class MyApp extends StatefulWidget {
   const MyApp({Key? key}) : super(key: key);
 
   @override
-  _MyAppState createState() => _MyAppState();
+  State<MyApp> createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {


### PR DESCRIPTION
in the example code, which a recommended lint (https://dart-lang.github.io/linter/lints/library_private_types_in_public_api.html).