### PR TITLE
Remove redundant casting.

### DIFF
--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/BackgroundService.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/BackgroundService.java
@@ -308,7 +308,7 @@ public class BackgroundService extends Service implements MethodChannel.MethodCa
             if (method.equalsIgnoreCase("sendData")) {
                 LocalBroadcastManager manager = LocalBroadcastManager.getInstance(this);
                 Intent intent = new Intent("id.flutter/background_service");
-                intent.putExtra("data", ((JSONObject) call.arguments).toString());
+                intent.putExtra("data", call.arguments.toString());
                 manager.sendBroadcast(intent);
                 result.success(true);
                 return;


### PR DESCRIPTION
As `.toString()` is applicable to `Object`, there is not need to cast. This fixes a warning in Android Studio.