### PR TITLE
Suppress deprecation warnings

### DIFF
--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/FlutterBackgroundServicePlugin.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/FlutterBackgroundServicePlugin.java
@@ -53,6 +53,7 @@ public class FlutterBackgroundServicePlugin extends BroadcastReceiver implements
     channel.setMethodCallHandler(this);
   }
 
+  @SuppressWarnings("deprecation")
   public static void registerWith(Registrar registrar) {
     LocalBroadcastManager localBroadcastManager = LocalBroadcastManager.getInstance(registrar.context());
     final FlutterBackgroundServicePlugin plugin = new FlutterBackgroundServicePlugin();
@@ -125,14 +126,7 @@ public class FlutterBackgroundServicePlugin extends BroadcastReceiver implements
       }
 
       if (method.equalsIgnoreCase("isServiceRunning")) {
-        ActivityManager manager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
-        for (ActivityManager.RunningServiceInfo service : manager.getRunningServices(Integer.MAX_VALUE)) {
-          if (BackgroundService.class.getName().equals(service.service.getClassName())) {
-            result.success(true);
-            return;
-          }
-        }
-        result.success(false);
+        result.success(isServiceRunning());
         return;
       }
 
@@ -140,6 +134,17 @@ public class FlutterBackgroundServicePlugin extends BroadcastReceiver implements
     }catch (Exception e) {
       result.error("100", "Failed read arguments", null);
     }
+  }
+
+  @SuppressWarnings("deprecation")
+  private boolean isServiceRunning() {
+    ActivityManager manager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+    for (ActivityManager.RunningServiceInfo service : manager.getRunningServices(Integer.MAX_VALUE)) {
+      if (BackgroundService.class.getName().equals(service.service.getClassName())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override


### PR DESCRIPTION
Part of #165

This PR has two changes:

1. `@SuppressWarnings("deprecation")` for Android v1 binding
2. Introduce new method `isServiceRunning`, which calls the deprecated [getRunningServices](https://developer.android.com/reference/android/app/ActivityManager#getRunningServices(int))