### PR TITLE
Better `return` for `setNotificationInfo` method

### DIFF
--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/BackgroundService.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/BackgroundService.java
@@ -260,8 +260,8 @@ public class BackgroundService extends Service implements MethodChannel.MethodCa
                     notificationContent = arg.getString("content");
                     updateNotificationInfo();
                     result.success(true);
-                    return;
                 }
+                return;
             }
 
             if (method.equalsIgnoreCase("setAutoStartOnBootMode")) {

--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/FlutterBackgroundServicePlugin.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/FlutterBackgroundServicePlugin.java
@@ -84,7 +84,6 @@ public class FlutterBackgroundServicePlugin extends BroadcastReceiver implements
     }
   }
 
-
   @Override
   public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
     String method = call.method;
@@ -137,7 +136,7 @@ public class FlutterBackgroundServicePlugin extends BroadcastReceiver implements
       }
 
       result.notImplemented();
-    }catch (Exception e) {
+    } catch (Exception e) {
       result.error("100", "Failed read arguments", null);
     }
   }
@@ -161,7 +160,7 @@ public class FlutterBackgroundServicePlugin extends BroadcastReceiver implements
         if (channel != null) {
           channel.invokeMethod("onReceiveData", jData);
         }
-      }catch (JSONException e) {
+      } catch (JSONException e) {
         e.printStackTrace();
       } catch (Exception e) {
         e.printStackTrace();


### PR DESCRIPTION
Previously, if the method is `setNotificationInfo` and the `arguments` have no `title`, the logic would continue to check the other method names.

Now, regardless of the `title` status, the logic would return after processing `setNotificationInfo` branch.