### PR TITLE
Add `@pragma('vm:entry-point')` to ensure Dart compiler finds the top-level functions

### DIFF
--- a/packages/flutter_background_service/example/lib/main.dart
+++ b/packages/flutter_background_service/example/lib/main.dart
@@ -48,6 +48,7 @@ bool onIosBackground(ServiceInstance service) {
   return true;
 }
 
+@pragma('vm:entry-point')
 void onStart(ServiceInstance service) async {
 
   // Only available for flutter 3.0.0 and later

--- a/packages/flutter_background_service_android/lib/flutter_background_service_android.dart
+++ b/packages/flutter_background_service_android/lib/flutter_background_service_android.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_background_service_platform_interface/flutter_background_service_platform_interface.dart';
 
+@pragma('vm:entry-point')
 Future<void> _entrypoint() async {
   WidgetsFlutterBinding.ensureInitialized();
   final service = AndroidServiceInstance._();


### PR DESCRIPTION
Fixes #172

This was tested with Flutter `master` and `3.0.2 stable`