### PR TITLE
Fix Android crash when attempting to unbind service

### DIFF
--- a/packages/flutter_background_service/pubspec.yaml
+++ b/packages/flutter_background_service/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
 
   flutter_background_service_platform_interface: ^2.1.4
-  flutter_background_service_android: ^2.5.0
+  flutter_background_service_android: ^2.5.1
   flutter_background_service_ios: ^2.2.5
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_background_service_android/CHANGELOG.md
+++ b/packages/flutter_background_service_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.5.1
+
+- **FIX**: Android crash when unbinding service
+
 ## 2.5.0
 
  - **FEAT**: added QUICKBOOT_POWERON action to intent-filter. ([46f08173](https://github.com/ekasetiawans/flutter_background_service/commit/46f08173cfb54795fb707bd521d8ed94db75cad5))

--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/FlutterBackgroundServicePlugin.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/FlutterBackgroundServicePlugin.java
@@ -35,6 +35,7 @@ public class FlutterBackgroundServicePlugin implements FlutterPlugin, MethodCall
     private MethodChannel channel;
     private Context context;
     private IBackgroundServiceBinder serviceBinder;
+    private boolean mShouldUnbind = false;
 
     @SuppressWarnings("deprecation")
     public static void registerWith(Registrar registrar) {
@@ -107,7 +108,7 @@ public class FlutterBackgroundServicePlugin implements FlutterPlugin, MethodCall
             context.startService(intent);
         }
 
-        context.bindService(intent, serviceConnection, Context.BIND_AUTO_CREATE);
+        mShouldUnbind = context.bindService(intent, serviceConnection, Context.BIND_AUTO_CREATE);
     }
 
     @Override
@@ -184,8 +185,9 @@ public class FlutterBackgroundServicePlugin implements FlutterPlugin, MethodCall
         channel.setMethodCallHandler(null);
         channel = null;
 
-        if (serviceBinder != null) {
+        if (mShouldUnbind) {
             binding.getApplicationContext().unbindService(serviceConnection);
+            mShouldUnbind = false;
         }
     }
 

--- a/packages/flutter_background_service_android/pubspec.yaml
+++ b/packages/flutter_background_service_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_background_service_android
 description: A flutter plugin for executing dart code continously even application closed.
-version: 2.5.0
+version: 2.5.1
 repository: https://github.com/ekasetiawans/flutter_background_service
 
 environment:


### PR DESCRIPTION
Check if we binded to the service before attempting to unbind. This is implemented based on the example docs here: https://developer.android.com/reference/android/app/Service.html

Fixes https://github.com/ekasetiawans/flutter_background_service/issues/218