### PR TITLE
added check before terminating serivece

### DIFF
--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/FlutterBackgroundServicePlugin.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/FlutterBackgroundServicePlugin.java
@@ -191,7 +191,7 @@ public class FlutterBackgroundServicePlugin implements FlutterPlugin, MethodCall
         channel.setMethodCallHandler(null);
         channel = null;
 
-        if (mShouldUnbind && serviceBinder != null) {
+        if (mShouldUnbind && serviceBinder != null && isServiceRunning()) {
             binding.getApplicationContext().unbindService(serviceConnection);
             mShouldUnbind = false;
         }


### PR DESCRIPTION
I have added check before terminating the service. As it was trying to re-close the service without checking that is was running in the first place. As your tracking variables we not enough to check whether the service is running or not.😊