### PR TITLE
feat: remove startService method

### DIFF
--- a/packages/flutter_background_service/example/lib/main.dart
+++ b/packages/flutter_background_service/example/lib/main.dart
@@ -39,7 +39,6 @@ Future<void> initializeService() async {
     );
   }
 
-
   await flutterLocalNotificationsPlugin
       .resolvePlatformSpecificImplementation<
           AndroidFlutterLocalNotificationsPlugin>()
@@ -70,8 +69,6 @@ Future<void> initializeService() async {
       onBackground: onIosBackground,
     ),
   );
-
-  service.startService();
 }
 
 // to ensure this is executed


### PR DESCRIPTION
related to issue #338 

Remove unnecessary command `.startService`  from the `initializeService()` method on the example.
The `onStart` will invoke if the `autoStart:true` 