### PR TITLE
Support for foreground services on Android 14

### DIFF
--- a/packages/flutter_background_service/README.md
+++ b/packages/flutter_background_service/README.md
@@ -6,7 +6,6 @@ A flutter plugin for execute dart code in background.
 
 ## Android
 
-- No additional setting is required.
 - To change notification icon, just add drawable icon with name `ic_bg_service_small`.
 
 > **WARNING**:
@@ -14,6 +13,36 @@ A flutter plugin for execute dart code in background.
 > Please make sure your project already use the version of gradle tools below:
 > - in android/build.gradle ```classpath 'com.android.tools.build:gradle:7.1.2'```
 > - in android/gradle/wrapper/gradle-wrapper.properties ```distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip```
+
+### Configuration required for Foreground Services on Android 14 (SDK 34)
+
+Applications that target SDK 34 and use foreground services need to include some additional configuration to declare the type of foreground service they use:
+
+* Determine the type of foreground service your app requires by consulting [the documentation](https://developer.android.com/about/versions/14/changes/fgs-types-required)
+* Update your `android/app/build.gradle` file to set the manifest placeholder to the value to use for `android:foregroundServiceType`:
+
+```gradle
+android {
+    ...
+
+    defaultConfig {
+        ...
+        manifestPlaceholders['foregroundServiceType'] = 'connectedDevice'
+    }
+}
+```
+
+* Add the corresponding permission to your `android/app/src/main/AndroidManifest.xml` file:
+
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools" package="com.example">
+  ...
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+  ...
+</manifest>
+```
+
+* Consult the documentation to determine if there are runtime permissions you need to request before you can start the service
 
 ### Using custom notification for Foreground Service
 You can make your own custom notification for foreground service. It can give you more power to make notifications more attractive to users, for example adding progressbars, buttons, actions, etc. The example below is using [flutter_local_notifications](https://pub.dev/packages/flutter_local_notifications) plugin, but you can use any other notification plugin. You can follow how to make it below:

--- a/packages/flutter_background_service/README.md
+++ b/packages/flutter_background_service/README.md
@@ -27,7 +27,9 @@ android {
 
     defaultConfig {
         ...
-        manifestPlaceholders['foregroundServiceType'] = 'connectedDevice'
+        // Replace this with the value to use for android:foregroundServiceType
+        // eg 'camera', 'connectedDevice', 'location', etc
+        manifestPlaceholders['foregroundServiceType'] = '...'
     }
 }
 ```
@@ -37,7 +39,12 @@ android {
 ```xml
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools" package="com.example">
   ...
-  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+  <!--
+    Permission to use here depends on the value you picked for foregroundServiceType - see the Android documentation.
+    Eg, if you picked 'location', use 'android.permission.FOREGROUND_SERVICE_LOCATION'
+  -->
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_..." />
   ...
 </manifest>
 ```

--- a/packages/flutter_background_service_android/android/build.gradle
+++ b/packages/flutter_background_service_android/android/build.gradle
@@ -35,5 +35,5 @@ android {
 }
 
 dependencies {
-
+  implementation "androidx.core:core:1.12.0"
 }

--- a/packages/flutter_background_service_android/android/src/main/AndroidManifest.xml
+++ b/packages/flutter_background_service_android/android/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
             android:exported="true"
             android:name=".BackgroundService"
             android:stopWithTask="false"
+            android:foregroundServiceType="${foregroundServiceType}"
             />
 
         <receiver

--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/BackgroundService.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/BackgroundService.java
@@ -11,6 +11,7 @@ import android.app.Service;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ServiceInfo;
 import android.os.Build;
 import android.os.Handler;
 import android.os.IBinder;
@@ -22,6 +23,7 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.core.app.NotificationCompat;
+import androidx.core.app.ServiceCompat;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -166,7 +168,11 @@ public class BackgroundService extends Service implements MethodChannel.MethodCa
                     .setContentText(notificationContent)
                     .setContentIntent(pi);
 
-            startForeground(notificationId, mBuilder.build());
+            try {
+              ServiceCompat.startForeground(this, notificationId, mBuilder.build(), ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST);
+            } catch (SecurityException e) {
+              Log.w(TAG, "Failed to start foreground service due to SecurityException - have you forgotten to request a permission? - " + e.getMessage());
+            }
         }
     }
 

--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/WatchdogReceiver.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/WatchdogReceiver.java
@@ -35,7 +35,16 @@ public class WatchdogReceiver extends BroadcastReceiver {
         PendingIntent pIntent = PendingIntent.getBroadcast(context, QUEUE_REQUEST_ID, intent, flags);
 
         // Check is background service every 5 seconds
-        AlarmManagerCompat.setExact(manager, AlarmManager.RTC_WAKEUP, System.currentTimeMillis() + millis, pIntent);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+          // Android 13 (SDK 33) requires apps to declare android.permission.SCHEDULE_EXACT_ALARM to use setExact
+          // Android 14 (SDK 34) takes this further and requires that apps explicitly ask for user permission before
+          //   using setExact.
+          // On these versions, use setAndAllowWhileIdle instead - it is _almost_ the same, but allows the OS to delay
+          // the alarm a bit to minimize device wake-ups
+          AlarmManagerCompat.setAndAllowWhileIdle(manager, AlarmManager.RTC_WAKEUP, System.currentTimeMillis() + millis, pIntent);
+        } else {
+          AlarmManagerCompat.setExact(manager, AlarmManager.RTC_WAKEUP, System.currentTimeMillis() + millis, pIntent);
+        }
     }
 
     public static void remove(Context context) {


### PR DESCRIPTION
Fixes https://github.com/ekasetiawans/flutter_background_service/issues/275

Android 14 (SDK 34) makes significant changes to the way foreground services work:
* Applications must declare a foregroundServiceType in the application manifest, and request relevant permissions before starting the service
* Use of setExact is now prohibited unless the application requests permission first

This addresses these issues by:
* Providing a way to set foregroundServiceType through a gradle manifest placeholder, and updates the README to instruct users how to configure this
* Replaces setExact with setAndAllowWhileIdle on Android SDK 33 or newer to avoid needing to request permissions