### PR TITLE
fix: stop using methodChannel after onDestroy (NullPointerException on BackgroundService.java:237)

### DIFF
--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/BackgroundService.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/BackgroundService.java
@@ -122,9 +122,9 @@ public class BackgroundService extends Service implements MethodChannel.MethodCa
             backgroundEngine = null;
         }
 
+        FlutterBackgroundServicePlugin.servicePipe.removeListener(listener);
         methodChannel = null;
         dartEntrypoint = null;
-        FlutterBackgroundServicePlugin.servicePipe.removeListener(listener);
         super.onDestroy();
     }
 

--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/BackgroundService.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/BackgroundService.java
@@ -235,18 +235,15 @@ public class BackgroundService extends Service implements MethodChannel.MethodCa
     }
 
     public void receiveData(JSONObject data) {
-        if (methodChannel != null) {
-            try {
-                final JSONObject arg = data;
-                mainHandler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        methodChannel.invokeMethod("onReceiveData", arg);
-                    }
-                });
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+        if (methodChannel == null) return;
+        try {
+            final JSONObject arg = data;
+            mainHandler.post(() -> {
+                if (methodChannel == null) return;
+                methodChannel.invokeMethod("onReceiveData", arg);
+            });
+        } catch (Exception e) {
+            e.printStackTrace();
         }
     }
 


### PR DESCRIPTION
Fixes cases where the `methodChannel` of `BackgroundService` was called inside `receiveData`, after turned null by `onDestroy`.

Issue caught:
![Screenshot 2023-11-10 at 10 05 36](https://github.com/ekasetiawans/flutter_background_service/assets/11656791/11bbe7d4-aa17-4585-b8ac-d5151e0d24b5)
