### PR TITLE
temp fix issue #375.

### DIFF
--- a/packages/flutter_background_service_android/lib/flutter_background_service_android.dart
+++ b/packages/flutter_background_service_android/lib/flutter_background_service_android.dart
@@ -12,7 +12,10 @@ bool _isMainIsolate = true;
 @pragma('vm:entry-point')
 Future<void> entrypoint(List<String> args) async {
   WidgetsFlutterBinding.ensureInitialized();
-  _isMainIsolate = false;
+
+  /// I have commented this line because it is causing issue on line 40, everytime we run the app. 
+  /// Related to issue #375.
+  // _isMainIsolate = false;
 
   final service = AndroidServiceInstance._();
   final int handle = int.parse(args.first);


### PR DESCRIPTION
Everytime we run the app, this line is causing issue. 
Why `_isMainIsolate` is first set to `true` and then to `false`. But then never changed back to `true`?

that's why it is throwing exception on line 40.
```
factory FlutterBackgroundServiceAndroid() {
    if (!_isMainIsolate) {
      throw Exception(
        "This class should only be used in the main isolate (UI App)",
      );
    }

    return _instance;
  }

```
I have tested the app in both the scenarios, it is working in both the scenarios whether it throws exception or not.

Can you please explain it?

Cheers, thanks.
