### PR TITLE
#403 also auto start service after app update

### DIFF
--- a/packages/flutter_background_service_android/android/src/main/AndroidManifest.xml
+++ b/packages/flutter_background_service_android/android/src/main/AndroidManifest.xml
@@ -28,6 +28,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED"/>
                 <action android:name="android.intent.action.QUICKBOOT_POWERON"/>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
             </intent-filter>
         </receiver>
 

--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/BootReceiver.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/BootReceiver.java
@@ -12,7 +12,7 @@ public class BootReceiver extends BroadcastReceiver {
     @SuppressLint("WakelockTimeout")
     @Override
     public void onReceive(Context context, Intent intent) {
-        if (intent.getAction().equals(Intent.ACTION_BOOT_COMPLETED) || intent.getAction().equals("android.intent.action.QUICKBOOT_POWERON")) {
+        if (intent.getAction().equals(Intent.ACTION_MY_PACKAGE_REPLACED) || intent.getAction().equals(Intent.ACTION_BOOT_COMPLETED) || intent.getAction().equals("android.intent.action.QUICKBOOT_POWERON")) {
             final Config config = new Config(context);
             boolean autoStart = config.isAutoStartOnBoot();
             if (autoStart) {


### PR DESCRIPTION
Expands the auto-start feature to also support the auto starting of the service after the app has been updated on Android.