### PR TITLE
Fix foreground crash on Android 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A flutter plugin for execute dart code in background.
 > - in android/build.gradle ```ext.kotlin_version = '1.8.10'```
 > - in android/gradle/wrapper/gradle-wrapper.properties ```distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip```
 
-### Configuration required for Foreground Services on Android 14 (SDK 34)
+### Configuration required for Foreground Services on Android 14+ (SDK 34)
 
 Applications that target SDK 34 and use foreground services need to include some additional configuration to declare the type of foreground service they use:
 
@@ -54,6 +54,20 @@ Applications that target SDK 34 and use foreground services need to include some
   ...
   </application>
 </manifest>
+```
+
+* Add the corresponding foreground service type to your AndroidConfiguration class:
+```dart
+await service.configure(
+    // IOS configuration
+    androidConfiguration: AndroidConfiguration(
+      ...
+      // Add this
+      foregroundServiceType: AndroidForegroundType.WhatForegroundServiceTypeDoYouWant
+      // Example:
+      // foregroundServiceType: AndroidForegroundType.mediaPlayback
+    ),
+  );
 ```
 
 > **WARNING**:

--- a/packages/flutter_background_service/example/lib/main.dart
+++ b/packages/flutter_background_service/example/lib/main.dart
@@ -57,6 +57,7 @@ Future<void> initializeService() async {
       initialNotificationTitle: 'AWESOME SERVICE',
       initialNotificationContent: 'Initializing',
       foregroundServiceNotificationId: 888,
+      foregroundServiceType: AndroidForegroundType.location,
     ),
     iosConfiguration: IosConfiguration(
       // auto start service

--- a/packages/flutter_background_service/lib/flutter_background_service.dart
+++ b/packages/flutter_background_service/lib/flutter_background_service.dart
@@ -5,10 +5,7 @@ import 'dart:async';
 import 'package:flutter_background_service_platform_interface/flutter_background_service_platform_interface.dart';
 
 export 'package:flutter_background_service_platform_interface/flutter_background_service_platform_interface.dart'
-    show IosConfiguration, AndroidConfiguration, ServiceInstance;
-
-export 'package:flutter_background_service_android/flutter_background_service_android.dart';
-export 'package:flutter_background_service_ios/flutter_background_service_ios.dart';
+    show IosConfiguration, AndroidConfiguration, ServiceInstance, AndroidForegroundType;
 
 class FlutterBackgroundService implements Observable {
   FlutterBackgroundServicePlatform get _platform =>

--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/BackgroundService.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/BackgroundService.java
@@ -58,6 +58,7 @@ public class BackgroundService extends Service implements MethodChannel.MethodCa
     private String notificationContent;
     private String notificationChannelId;
     private int notificationId;
+    private String foregroundType;
     private Handler mainHandler;
 
     synchronized public static PowerManager.WakeLock getLock(Context context) {
@@ -102,6 +103,7 @@ public class BackgroundService extends Service implements MethodChannel.MethodCa
         notificationTitle = config.getInitialNotificationTitle();
         notificationContent = config.getInitialNotificationContent();
         notificationId = config.getForegroundNotificationId();
+        foregroundType = config.getForegroundServiceType();
         updateNotificationInfo();
         onStartCommand(null, -1, -1);
     }
@@ -169,7 +171,8 @@ public class BackgroundService extends Service implements MethodChannel.MethodCa
                     .setContentIntent(pi);
 
             try {
-                ServiceCompat.startForeground(this, notificationId, mBuilder.build(), ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST);
+                Integer serviceType = ForegroundTypeMapper.getForegroundServiceType(foregroundType);
+                ServiceCompat.startForeground(this, notificationId, mBuilder.build(), serviceType);
             } catch (SecurityException e) {
               Log.w(TAG, "Failed to start foreground service due to SecurityException - have you forgotten to request a permission? - " + e.getMessage());
             }

--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/Config.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/Config.java
@@ -77,4 +77,13 @@ public class Config {
     public void setForegroundNotificationId(int value) {
         pref.edit().putInt("foreground_notification_id", value).apply();
     }
+
+    public String getForegroundServiceType() {
+        return pref.getString("foreground_service_type", null);
+    }
+
+    public void setForegroundServiceType(String value) {
+        pref.edit().putString("foreground_service_type", value).apply();
+    }
+
 }

--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/FlutterBackgroundServicePlugin.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/FlutterBackgroundServicePlugin.java
@@ -100,6 +100,7 @@ public class FlutterBackgroundServicePlugin implements FlutterPlugin, MethodCall
                 String initialNotificationContent = arg.isNull("initial_notification_content") ? null : arg.getString("initial_notification_content");
                 String notificationChannelId = arg.isNull("notification_channel_id") ? null : arg.getString("notification_channel_id");
                 int foregroundNotificationId = arg.isNull("foreground_notification_id") ? null : arg.getInt("foreground_notification_id");
+                String foregroundServiceType = arg.isNull("foreground_service_type") ? null : arg.getString("foreground_service_type");
 
                 config.setBackgroundHandle(backgroundHandle);
                 config.setIsForeground(isForeground);
@@ -108,6 +109,7 @@ public class FlutterBackgroundServicePlugin implements FlutterPlugin, MethodCall
                 config.setInitialNotificationContent(initialNotificationContent);
                 config.setNotificationChannelId(notificationChannelId);
                 config.setForegroundNotificationId(foregroundNotificationId);
+                config.setForegroundServiceType(foregroundServiceType);
 
                 if (autoStart) {
                     start();

--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/ForegroundTypeMapper.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/ForegroundTypeMapper.java
@@ -1,0 +1,34 @@
+package id.flutter.flutter_background_service;
+
+import android.app.Service;
+import android.content.pm.ServiceInfo;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ForegroundTypeMapper {
+
+    private static final Map<String, Integer> foregroundTypeMap = new HashMap<>();
+
+    static {
+        foregroundTypeMap.put("camera", ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA);
+        foregroundTypeMap.put("connectedDevice", ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE);
+        foregroundTypeMap.put("dataSync", ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC);
+        foregroundTypeMap.put("health", ServiceInfo.FOREGROUND_SERVICE_TYPE_HEALTH);
+        foregroundTypeMap.put("location", ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION);
+        foregroundTypeMap.put("mediaPlayback", ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK);
+        foregroundTypeMap.put("mediaProjection", ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION);
+        foregroundTypeMap.put("microphone", ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE);
+        foregroundTypeMap.put("phoneCall", ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL);
+        foregroundTypeMap.put("remoteMessaging", ServiceInfo.FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING);
+        foregroundTypeMap.put("shortService", ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE);
+        foregroundTypeMap.put("specialUse", ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE);
+        foregroundTypeMap.put("systemExempted", ServiceInfo.FOREGROUND_SERVICE_TYPE_SYSTEM_EXEMPTED);
+    }
+
+    public static Integer getForegroundServiceType(String foregroundType) {
+        if (foregroundType == null) {
+            return ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST;
+        }
+        return foregroundTypeMap.get(foregroundType);
+    }
+}

--- a/packages/flutter_background_service_android/lib/flutter_background_service_android.dart
+++ b/packages/flutter_background_service_android/lib/flutter_background_service_android.dart
@@ -104,6 +104,8 @@ class FlutterBackgroundServiceAndroid extends FlutterBackgroundServicePlatform {
         "notification_channel_id": androidConfiguration.notificationChannelId,
         "foreground_notification_id":
             androidConfiguration.foregroundServiceNotificationId,
+        "foreground_service_type":
+            androidConfiguration.foregroundServiceType?.name,
       },
     );
 

--- a/packages/flutter_background_service_platform_interface/lib/src/configs.dart
+++ b/packages/flutter_background_service_platform_interface/lib/src/configs.dart
@@ -23,6 +23,22 @@ class IosConfiguration {
   });
 }
 
+enum AndroidForegroundType {
+  camera,
+  connectedDevice,
+  dataSync,
+  health,
+  location,
+  mediaPlayback,
+  mediaProjection,
+  microphone,
+  phoneCall,
+  remoteMessaging,
+  shortService,
+  specialUse,
+  systemExempted
+}
+
 class AndroidConfiguration {
   /// must be a top level or static method
   final Function(ServiceInstance service) onStart;
@@ -47,6 +63,7 @@ class AndroidConfiguration {
 
   /// notification id will be used by foreground service
   final int foregroundServiceNotificationId;
+  final AndroidForegroundType? foregroundServiceType;
 
   AndroidConfiguration({
     required this.onStart,
@@ -57,5 +74,6 @@ class AndroidConfiguration {
     this.initialNotificationTitle = 'Background Service',
     this.notificationChannelId,
     this.foregroundServiceNotificationId = 112233,
+    this.foregroundServiceType,
   });
 }


### PR DESCRIPTION
In Android 14, the package started crashing because ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST is no longer a valid foreground service type as per the new [documentation](https://developer.android.com/about/versions/14/changes/fgs-types-required). 
I have added a new enum to specify the required foreground service type. Additionally, I updated the README and the example project to reflect these changes. 
Issues: #460, #461 #459 #457 #453 