### PR TITLE
fix: re-added exports for Android and iOS services.

### DIFF
--- a/packages/flutter_background_service/lib/flutter_background_service.dart
+++ b/packages/flutter_background_service/lib/flutter_background_service.dart
@@ -7,6 +7,9 @@ import 'package:flutter_background_service_platform_interface/flutter_background
 export 'package:flutter_background_service_platform_interface/flutter_background_service_platform_interface.dart'
     show IosConfiguration, AndroidConfiguration, ServiceInstance, AndroidForegroundType;
 
+export 'package:flutter_background_service_android/flutter_background_service_android.dart';
+export 'package:flutter_background_service_ios/flutter_background_service_ios.dart';
+
 class FlutterBackgroundService implements Observable {
   FlutterBackgroundServicePlatform get _platform =>
       FlutterBackgroundServicePlatform.instance;


### PR DESCRIPTION
In my last PR, my branch was synced with v5.0.5, causing some exports added in v5.0.6 to be lost. The issue was reported in #466 