### PR TITLE
feat: support multiple foreground service types

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A flutter plugin for execute dart code in background.
 
 Applications that target SDK 34 and use foreground services need to include some additional configuration to declare the type of foreground service they use:
 
-* Determine the type of foreground service your app requires by consulting [the documentation](https://developer.android.com/about/versions/14/changes/fgs-types-required)
+* Determine the type or types of foreground service your app requires by consulting [the documentation](https://developer.android.com/about/versions/14/changes/fgs-types-required)
 
 * Add the corresponding permission to your `android/app/src/main/AndroidManifest.xml` file:
 
@@ -30,6 +30,10 @@ Applications that target SDK 34 and use foreground services need to include some
   <!--
     Permission to use here depends on the value you picked for foregroundServiceType - see the Android documentation.
     Eg, if you picked 'location', use 'android.permission.FOREGROUND_SERVICE_LOCATION'
+  -->
+  <!--
+    If you need more than 1 type, you must separate each type by a pipe(|) symbol - see the Android documentation.
+    Eg, android:foregroundServiceType="location|mediaPlayback"
   -->
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_..." />
   <application
@@ -46,7 +50,7 @@ Applications that target SDK 34 and use foreground services need to include some
         <!--Add this-->
         <service
             android:name="id.flutter.flutter_background_service.BackgroundService"
-            android:foregroundServiceType="WhatForegroundServiceTypeDoYouWant"
+            android:foregroundServiceType="WhatForegroundServiceTypesDoYouWant"
         />
         <!--end-->
 
@@ -56,7 +60,7 @@ Applications that target SDK 34 and use foreground services need to include some
 </manifest>
 ```
 
-* Add the corresponding foreground service type to your AndroidConfiguration class:
+* Add the corresponding foreground service types to your AndroidConfiguration class:
 ```dart
 await service.configure(
     // IOS configuration
@@ -72,6 +76,7 @@ await service.configure(
 
 > **WARNING**:
 > * YOU MUST MAKE SURE ANY REQUIRED PERMISSIONS TO BE GRANTED BEFORE YOU START THE SERVICE
+> * THE TYPES YOU PUT IN foregroundServiceTypes, MUST BE DECLARED IN MANIFEST
 
 
 ### Using custom notification for Foreground Service

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ await service.configure(
     androidConfiguration: AndroidConfiguration(
       ...
       // Add this
-      foregroundServiceType: AndroidForegroundType.WhatForegroundServiceTypeDoYouWant
+      foregroundServiceTypes: [AndroidForegroundType.WhatForegroundServiceTypeDoYouWant]
       // Example:
-      // foregroundServiceType: AndroidForegroundType.mediaPlayback
+      // foregroundServiceTypes: [AndroidForegroundType.mediaPlayback]
     ),
   );
 ```

--- a/packages/flutter_background_service/example/lib/main.dart
+++ b/packages/flutter_background_service/example/lib/main.dart
@@ -57,7 +57,7 @@ Future<void> initializeService() async {
       initialNotificationTitle: 'AWESOME SERVICE',
       initialNotificationContent: 'Initializing',
       foregroundServiceNotificationId: 888,
-      foregroundServiceType: AndroidForegroundType.location,
+      foregroundServiceTypes: [AndroidForegroundType.location],
     ),
     iosConfiguration: IosConfiguration(
       // auto start service

--- a/packages/flutter_background_service/lib/flutter_background_service.dart
+++ b/packages/flutter_background_service/lib/flutter_background_service.dart
@@ -7,6 +7,9 @@ import 'package:flutter_background_service_platform_interface/flutter_background
 export 'package:flutter_background_service_platform_interface/flutter_background_service_platform_interface.dart'
     show IosConfiguration, AndroidConfiguration, ServiceInstance, AndroidForegroundType;
 
+export 'package:flutter_background_service_android/flutter_background_service_android.dart';
+export 'package:flutter_background_service_ios/flutter_background_service_ios.dart';
+
 class FlutterBackgroundService implements Observable {
   FlutterBackgroundServicePlatform get _platform =>
       FlutterBackgroundServicePlatform.instance;

--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/BackgroundService.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/BackgroundService.java
@@ -28,8 +28,6 @@ import androidx.core.app.ServiceCompat;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.io.ObjectInputFilter.Config;
-import java.nio.channels.Pipe;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/BackgroundService.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/BackgroundService.java
@@ -28,6 +28,8 @@ import androidx.core.app.ServiceCompat;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.ObjectInputFilter.Config;
+import java.nio.channels.Pipe;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -58,7 +60,8 @@ public class BackgroundService extends Service implements MethodChannel.MethodCa
     private String notificationContent;
     private String notificationChannelId;
     private int notificationId;
-    private String foregroundType;
+    private String configForegroundTypes;
+    private String[] foregroundTypes;
     private Handler mainHandler;
 
     synchronized public static PowerManager.WakeLock getLock(Context context) {
@@ -103,7 +106,7 @@ public class BackgroundService extends Service implements MethodChannel.MethodCa
         notificationTitle = config.getInitialNotificationTitle();
         notificationContent = config.getInitialNotificationContent();
         notificationId = config.getForegroundNotificationId();
-        foregroundType = config.getForegroundServiceType();
+        configForegroundTypes = config.getForegroundServiceTypes();
         updateNotificationInfo();
         onStartCommand(null, -1, -1);
     }
@@ -171,7 +174,11 @@ public class BackgroundService extends Service implements MethodChannel.MethodCa
                     .setContentIntent(pi);
 
             try {
-                Integer serviceType = ForegroundTypeMapper.getForegroundServiceType(foregroundType);
+                foregroundTypes = null;
+                if (configForegroundTypes != null && !configForegroundTypes.isEmpty()) {
+                    foregroundTypes = configForegroundTypes.split(",");
+                }
+                Integer serviceType = ForegroundTypeMapper.getForegroundServiceType(foregroundTypes);
                 ServiceCompat.startForeground(this, notificationId, mBuilder.build(), serviceType);
             } catch (SecurityException e) {
               Log.w(TAG, "Failed to start foreground service due to SecurityException - have you forgotten to request a permission? - " + e.getMessage());

--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/Config.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/Config.java
@@ -78,12 +78,12 @@ public class Config {
         pref.edit().putInt("foreground_notification_id", value).apply();
     }
 
-    public String getForegroundServiceType() {
-        return pref.getString("foreground_service_type", null);
+    public String getForegroundServiceTypes() {
+        return pref.getString("foreground_service_types", null);
     }
 
-    public void setForegroundServiceType(String value) {
-        pref.edit().putString("foreground_service_type", value).apply();
+    public void setForegroundServiceTypes(String value) {
+        pref.edit().putString("foreground_service_types", value).apply();
     }
 
 }

--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/FlutterBackgroundServicePlugin.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/FlutterBackgroundServicePlugin.java
@@ -15,7 +15,6 @@ import androidx.core.content.ContextCompat;
 import org.json.JSONObject;
 import org.json.JSONArray;
 
-import java.nio.channels.Pipe;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/FlutterBackgroundServicePlugin.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/FlutterBackgroundServicePlugin.java
@@ -13,7 +13,9 @@ import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 
 import org.json.JSONObject;
+import org.json.JSONArray;
 
+import java.nio.channels.Pipe;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -100,7 +102,18 @@ public class FlutterBackgroundServicePlugin implements FlutterPlugin, MethodCall
                 String initialNotificationContent = arg.isNull("initial_notification_content") ? null : arg.getString("initial_notification_content");
                 String notificationChannelId = arg.isNull("notification_channel_id") ? null : arg.getString("notification_channel_id");
                 int foregroundNotificationId = arg.isNull("foreground_notification_id") ? null : arg.getInt("foreground_notification_id");
-                String foregroundServiceType = arg.isNull("foreground_service_type") ? null : arg.getString("foreground_service_type");
+                JSONArray foregroundServiceTypes = arg.isNull("foreground_service_types") ? null : arg.getJSONArray("foreground_service_types");
+                String foregroundServiceTypesStr = null;
+                if (foregroundServiceTypes != null) {
+                    StringBuilder resultForegroundServiceType = new StringBuilder();
+                    for (int i = 0; i < foregroundServiceTypes.length(); i++) {
+                        resultForegroundServiceType.append(foregroundServiceTypes.getString(i));
+                        if (i < foregroundServiceTypes.length() - 1) {
+                            resultForegroundServiceType.append(",");
+                        }
+                    }
+                    foregroundServiceTypesStr = resultForegroundServiceType.toString();
+                }
 
                 config.setBackgroundHandle(backgroundHandle);
                 config.setIsForeground(isForeground);
@@ -109,7 +122,7 @@ public class FlutterBackgroundServicePlugin implements FlutterPlugin, MethodCall
                 config.setInitialNotificationContent(initialNotificationContent);
                 config.setNotificationChannelId(notificationChannelId);
                 config.setForegroundNotificationId(foregroundNotificationId);
-                config.setForegroundServiceType(foregroundServiceType);
+                config.setForegroundServiceTypes(foregroundServiceTypesStr);
 
                 if (autoStart) {
                     start();

--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/ForegroundTypeMapper.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/ForegroundTypeMapper.java
@@ -25,10 +25,13 @@ public class ForegroundTypeMapper {
         foregroundTypeMap.put("systemExempted", ServiceInfo.FOREGROUND_SERVICE_TYPE_SYSTEM_EXEMPTED);
     }
 
-    public static Integer getForegroundServiceType(String foregroundType) {
-        if (foregroundType == null) {
-            return ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST;
+    public static Integer getForegroundServiceType(String[] foregroundTypes) {
+        Integer foregroundServiceType = ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST;
+        if (foregroundTypes != null && foregroundTypes.length > 0) {
+            for (String foregroundType : foregroundTypes) {
+                foregroundServiceType |= foregroundTypeMap.get(foregroundType);
+            }
         }
-        return foregroundTypeMap.get(foregroundType);
+        return foregroundServiceType;
     }
 }

--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/ForegroundTypeMapper.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/ForegroundTypeMapper.java
@@ -28,6 +28,7 @@ public class ForegroundTypeMapper {
     public static Integer getForegroundServiceType(String[] foregroundTypes) {
         Integer foregroundServiceType = ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST;
         if (foregroundTypes != null && foregroundTypes.length > 0) {
+            foregroundServiceType = 0;
             for (String foregroundType : foregroundTypes) {
                 foregroundServiceType |= foregroundTypeMap.get(foregroundType);
             }

--- a/packages/flutter_background_service_android/lib/flutter_background_service_android.dart
+++ b/packages/flutter_background_service_android/lib/flutter_background_service_android.dart
@@ -90,6 +90,16 @@ class FlutterBackgroundServiceAndroid extends FlutterBackgroundServicePlatform {
       throw 'onStart method must be a top-level or static function';
     }
 
+    List<AndroidForegroundType>? configForegroundServiceTypes =
+        androidConfiguration.foregroundServiceTypes;
+    List<String>? foregroundServiceTypes;
+    if (configForegroundServiceTypes != null && configForegroundServiceTypes!.length > 0) {
+      foregroundServiceTypes = [];
+      androidConfiguration.foregroundServiceTypes!.forEach((foregroundServiceType) {
+        foregroundServiceTypes!.add(foregroundServiceType.name);
+      });
+    }
+
     final result = await _channel.invokeMethod(
       "configure",
       {
@@ -104,8 +114,7 @@ class FlutterBackgroundServiceAndroid extends FlutterBackgroundServicePlatform {
         "notification_channel_id": androidConfiguration.notificationChannelId,
         "foreground_notification_id":
             androidConfiguration.foregroundServiceNotificationId,
-        "foreground_service_type":
-            androidConfiguration.foregroundServiceType?.name,
+        "foreground_service_types": foregroundServiceTypes,
       },
     );
 

--- a/packages/flutter_background_service_platform_interface/lib/src/configs.dart
+++ b/packages/flutter_background_service_platform_interface/lib/src/configs.dart
@@ -63,7 +63,9 @@ class AndroidConfiguration {
 
   /// notification id will be used by foreground service
   final int foregroundServiceNotificationId;
-  final AndroidForegroundType? foregroundServiceType;
+
+  /// foreground service types
+  final List<AndroidForegroundType>? foregroundServiceTypes;
 
   AndroidConfiguration({
     required this.onStart,
@@ -74,6 +76,6 @@ class AndroidConfiguration {
     this.initialNotificationTitle = 'Background Service',
     this.notificationChannelId,
     this.foregroundServiceNotificationId = 112233,
-    this.foregroundServiceType,
+    this.foregroundServiceTypes,
   });
 }


### PR DESCRIPTION
The changes that came with #463, support only 1 type for the service. [The documentation](https://developer.android.com/about/versions/14/changes/fgs-types-required#include-fgs-type-runtime) has a section indicating that more than 1 type can be declared at the time of starting the service, which is my case within my application.

I have changed several parts of the code that came with the previous PR so it can receive more than one type and this list is used when starting the service.

**Breaking change with version 5.0.7**
- Renaming on AndroidConfiguration from foregroundServiceType to **foregroundServiceTypes**
- Changing data type on AndroidConfiguration, the variable foregroundServiceTypes from `final AndroidForegroundType?` to `final List<AndroidForegroundType>?`

I am open to any kind of comments about changes that are needed to this code(Sorry if something is not understood, my main language is Spanish).

