### PR TITLE
bug: [Android-14]-service-crash-due-to-START_STICKY

### DIFF
--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/BackgroundService.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/BackgroundService.java
@@ -190,7 +190,7 @@ public class BackgroundService extends Service implements MethodChannel.MethodCa
         WatchdogReceiver.enqueue(this);
         runService();
 
-        return START_STICKY;
+        return START_NOT_STICKY;
     }
 
     @SuppressLint("WakelockTimeout")


### PR DESCRIPTION
Added fix for issue: https://github.com/ekasetiawans/flutter_background_service/issues/476

Changed return value to `START_NOT_STICKY` in `onStartCommand`

This should be a non-issue for service stability since the `WatchdogReciever` ensures that the service is restarted in the package and should allow us to remove `START_STICKY` without any negative consequences