### PR TITLE
fix: no SCHEDULE_EXACT_ALARMS permission on android 12 causes an exception

### DIFF
--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/WatchdogReceiver.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/WatchdogReceiver.java
@@ -10,6 +10,10 @@ import android.app.ActivityManager;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
+import android.Manifest;
+import android.content.Context;
+import android.content.pm.PackageManager;
+
 
 import androidx.core.app.AlarmManagerCompat;
 import androidx.core.content.ContextCompat;
@@ -34,8 +38,17 @@ public class WatchdogReceiver extends BroadcastReceiver {
 
         PendingIntent pIntent = PendingIntent.getBroadcast(context, QUEUE_REQUEST_ID, intent, flags);
 
+        // On some vendored Android 12 (SDK 32) SCHEDULE_EXACT_ALARM permission might not be granted
+        // by default.
+        boolean isScheduleExactAlarmsGranted = true;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            isScheduleExactAlarmsGranted = PackageManager.PERMISSION_GRANTED == context.checkSelfPermission(
+                    Manifest.permission.SCHEDULE_EXACT_ALARM
+            );
+        }
+
         // Check is background service every 5 seconds
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU || !isScheduleExactAlarmsGranted) {
           // Android 13 (SDK 33) requires apps to declare android.permission.SCHEDULE_EXACT_ALARM to use setExact
           // Android 14 (SDK 34) takes this further and requires that apps explicitly ask for user permission before
           //   using setExact.


### PR DESCRIPTION
Resolves issues: #435 #471