### PR TITLE
fix(android): add namespace to support AGP 8.0+

### DIFF
--- a/packages/flutter_background_service_android/android/build.gradle
+++ b/packages/flutter_background_service_android/android/build.gradle
@@ -23,7 +23,9 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 34
+
     namespace = "id.flutter.flutter_background_service"
+    
     defaultConfig {
         minSdkVersion 16
         consumerProguardFiles 'proguard-rules.pro'


### PR DESCRIPTION
Added the required `namespace` declaration in build.gradle for flutter_background_service_android to be compatible with Android Gradle Plugin 8.0 and above.
