### PR TITLE
Added a hook for FlutterEngine creation

### DIFF
--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/BackgroundService.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/BackgroundService.java
@@ -55,6 +55,14 @@ public class BackgroundService extends Service implements MethodChannel.MethodCa
     private String[] foregroundTypes;
     private Handler mainHandler;
 
+    // Hook for allowing custom plugin registration
+    public static FlutterEngineHook engineHook;
+
+    public interface FlutterEngineHook {
+        void onEngineCreated(FlutterEngine engine);
+    }
+
+
     synchronized public static PowerManager.WakeLock getLock(Context context) {
         if (lockStatic == null) {
             PowerManager mgr = (PowerManager) context
@@ -209,6 +217,11 @@ public class BackgroundService extends Service implements MethodChannel.MethodCa
 
             isRunning.set(true);
             backgroundEngine = new FlutterEngine(this);
+
+            // Call the custom hook, if it's set
+            if (engineHook != null) {
+                engineHook.onEngineCreated(backgroundEngine);
+            }
 
             // remove FlutterBackgroundServicePlugin (because its only for UI)
             backgroundEngine.getPlugins().remove(FlutterBackgroundServicePlugin.class);


### PR DESCRIPTION
When developing native Android code, it's not possible to use the code within the current background service implementation. I added a hook method to allow access to the FlutterEngine created by the background service plugin.