### PR TITLE
Trying to fix the notification stuck on preparing stage.

### DIFF
--- a/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/BackgroundService.java
+++ b/packages/flutter_background_service_android/android/src/main/java/id/flutter/flutter_background_service/BackgroundService.java
@@ -189,7 +189,7 @@ public class BackgroundService extends Service implements MethodChannel.MethodCa
     @SuppressLint("WakelockTimeout")
     private void runService() {
         try {
-            if (isRunning.get() || (backgroundEngine != null && !backgroundEngine.getDartExecutor().isExecutingDart())) {
+            if (isRunning.get() || (backgroundEngine != null && backgroundEngine.getDartExecutor().isExecutingDart())) {
                 Log.v(TAG, "Service already running, using existing service");
                 return;
             }


### PR DESCRIPTION
I got this error where sometimes the notification sayed preparing and was stuck on that stage and i tried to fix it using ai so it made this chnage. Im not quite sure how it will help but here it is. 

Summary
Fixed the Android service startup guard so it only short-circuits when an existing backgroundEngine is actually executing Dart. Previously, a non-executing engine was treated as “already running,” which could skip engine re-init and leave startup stuck on preparing. 

The change is localized to BackgroundService.runService() and keeps the normal startup path intact (acquire wakelock, notification update, Flutter init, engine creation) when the engine is not running. 


The original condition said “already running” when backgroundEngine existed and was not executing Dart, then returned early. That is internally inconsistent and can block re-initialization exactly when recovery is needed. In other words, if the engine object existed but wasn’t running, the service skipped startup and could stay in a “preparing” state. 

I verified this by comparing before/after:

Before: backgroundEngine != null && !...isExecutingDart() caused early return.

After: backgroundEngine != null && ...isExecutingDart() only returns early when it is truly running. 